### PR TITLE
👕  Adding explicit import to make tsc on node 7 happy.

### DIFF
--- a/src/factories/array.ts
+++ b/src/factories/array.ts
@@ -4,5 +4,5 @@ import { makeSchema } from '../utils/make-schema';
 import { JSONSchemaType } from '../constants/json-schema-type';
 
 export function array(options: TOptions<TArrayJSONSchema> = {}) {
-  return makeSchema(Object.assign(options, { additionalItems: options.additionalItems || false }), JSONSchemaType.ARRAY);
+  return makeSchema<TArrayJSONSchema>(Object.assign(options, { additionalItems: options.additionalItems || false }), JSONSchemaType.ARRAY);
 }


### PR DESCRIPTION
Current error on node 7:
```
src/factories/array.ts(6,17): error TS4058: Return type of exported function has or is using name 'TJSONSchema' from external module "/home/travis/build/bluebirds-blue-jay/schema/src/types/json-schema" but cannot be named.
```