### PR TITLE
✨ Added mergeWith

### DIFF
--- a/docs/enums/jsonschematype.html
+++ b/docs/enums/jsonschematype.html
@@ -91,7 +91,7 @@
 					<div class="tsd-signature tsd-kind-icon">ARRAY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;array&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/constants/json-schema-type.ts#L3">src/constants/json-schema-type.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/constants/json-schema-type.ts#L3">src/constants/json-schema-type.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">BOOLEAN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;boolean&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/constants/json-schema-type.ts#L6">src/constants/json-schema-type.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/constants/json-schema-type.ts#L6">src/constants/json-schema-type.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">INTEGER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;integer&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/constants/json-schema-type.ts#L5">src/constants/json-schema-type.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/constants/json-schema-type.ts#L5">src/constants/json-schema-type.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">NULL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;null&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/constants/json-schema-type.ts#L7">src/constants/json-schema-type.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/constants/json-schema-type.ts#L7">src/constants/json-schema-type.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">NUMBER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;number&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/constants/json-schema-type.ts#L8">src/constants/json-schema-type.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/constants/json-schema-type.ts#L8">src/constants/json-schema-type.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">OBJECT<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;object&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/constants/json-schema-type.ts#L2">src/constants/json-schema-type.ts:2</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/constants/json-schema-type.ts#L2">src/constants/json-schema-type.ts:2</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">STRING<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;string&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/constants/json-schema-type.ts#L4">src/constants/json-schema-type.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/constants/json-schema-type.ts#L4">src/constants/json-schema-type.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -268,6 +268,9 @@
 					</li>
 					<li class=" tsd-kind-function">
 						<a href="../globals.html#list" class="tsd-kind-icon">list</a>
+					</li>
+					<li class=" tsd-kind-function tsd-has-type-parameter">
+						<a href="../globals.html#mergewith" class="tsd-kind-icon">merge<wbr>With</a>
 					</li>
 					<li class=" tsd-kind-function">
 						<a href="../globals.html#number" class="tsd-kind-icon">number</a>

--- a/docs/enums/jsonstringformat.html
+++ b/docs/enums/jsonstringformat.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">DATE_<wbr>TIME<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;date-time&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/constants/json-string-format.ts#L2">src/constants/json-string-format.ts:2</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/constants/json-string-format.ts#L2">src/constants/json-string-format.ts:2</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">EMAIL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;email&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/constants/json-string-format.ts#L3">src/constants/json-string-format.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/constants/json-string-format.ts#L3">src/constants/json-string-format.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">HOSTNAME<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;hostname&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/constants/json-string-format.ts#L4">src/constants/json-string-format.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/constants/json-string-format.ts#L4">src/constants/json-string-format.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">IPV4<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;ipv4&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/constants/json-string-format.ts#L5">src/constants/json-string-format.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/constants/json-string-format.ts#L5">src/constants/json-string-format.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">IPV6<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;ipv6&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/constants/json-string-format.ts#L6">src/constants/json-string-format.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/constants/json-string-format.ts#L6">src/constants/json-string-format.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">URI<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;&quot;uri&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/constants/json-string-format.ts#L7">src/constants/json-string-format.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/constants/json-string-format.ts#L7">src/constants/json-string-format.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -254,6 +254,9 @@
 					</li>
 					<li class=" tsd-kind-function">
 						<a href="../globals.html#list" class="tsd-kind-icon">list</a>
+					</li>
+					<li class=" tsd-kind-function tsd-has-type-parameter">
+						<a href="../globals.html#mergewith" class="tsd-kind-icon">merge<wbr>With</a>
 					</li>
 					<li class=" tsd-kind-function">
 						<a href="../globals.html#number" class="tsd-kind-icon">number</a>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -108,6 +108,7 @@
 								<li class="tsd-kind-function tsd-has-type-parameter"><a href="globals.html#enumeration" class="tsd-kind-icon">enumeration</a></li>
 								<li class="tsd-kind-function"><a href="globals.html#integer" class="tsd-kind-icon">integer</a></li>
 								<li class="tsd-kind-function"><a href="globals.html#list" class="tsd-kind-icon">list</a></li>
+								<li class="tsd-kind-function tsd-has-type-parameter"><a href="globals.html#mergewith" class="tsd-kind-icon">merge<wbr>With</a></li>
 								<li class="tsd-kind-function"><a href="globals.html#number" class="tsd-kind-icon">number</a></li>
 								<li class="tsd-kind-function"><a href="globals.html#object" class="tsd-kind-icon">object</a></li>
 								<li class="tsd-kind-function"><a href="globals.html#omitproperties" class="tsd-kind-icon">omit<wbr>Properties</a></li>
@@ -131,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">TArrayJSONSchema<span class="tsd-signature-symbol">:</span> <a href="globals.html#tjsonschema" class="tsd-signature-type">TJSONSchema</a><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/types/array-json-schema.ts#L4">src/types/array-json-schema.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/types/array-json-schema.ts#L4">src/types/array-json-schema.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">TBooleanJSONSchema<span class="tsd-signature-symbol">:</span> <a href="globals.html#tjsonschema" class="tsd-signature-type">TJSONSchema</a><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/types/boolean-json-schema.ts#L4">src/types/boolean-json-schema.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/types/boolean-json-schema.ts#L4">src/types/boolean-json-schema.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">TCommon<wbr>Options<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/types/common-options.ts#L1">src/types/common-options.ts:1</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/types/common-options.ts#L1">src/types/common-options.ts:1</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">TIntegerJSONSchema<span class="tsd-signature-symbol">:</span> <a href="globals.html#tnumberjsonschema" class="tsd-signature-type">TNumberJSONSchema</a><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/types/integer-json-schema.ts#L4">src/types/integer-json-schema.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/types/integer-json-schema.ts#L4">src/types/integer-json-schema.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">TJSONSchema<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/types/json-schema.ts#L3">src/types/json-schema.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/types/json-schema.ts#L3">src/types/json-schema.ts:3</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -253,7 +254,7 @@
 					<div class="tsd-signature tsd-kind-icon">TNumberJSONSchema<span class="tsd-signature-symbol">:</span> <a href="globals.html#tjsonschema" class="tsd-signature-type">TJSONSchema</a><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/types/number-json-schema.ts#L4">src/types/number-json-schema.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/types/number-json-schema.ts#L4">src/types/number-json-schema.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -263,7 +264,7 @@
 					<div class="tsd-signature tsd-kind-icon">TObjectJSONSchema<span class="tsd-signature-symbol">:</span> <a href="globals.html#tjsonschema" class="tsd-signature-type">TJSONSchema</a><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/types/object-json-schema.ts#L3">src/types/object-json-schema.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/types/object-json-schema.ts#L3">src/types/object-json-schema.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -273,7 +274,7 @@
 					<div class="tsd-signature tsd-kind-icon">TOptions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><a href="globals.html#tcommonoptions" class="tsd-signature-type">TCommonOptions</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/types/options.ts#L3">src/types/options.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/types/options.ts#L3">src/types/options.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -283,7 +284,7 @@
 					<div class="tsd-signature tsd-kind-icon">TStringJSONSchema<span class="tsd-signature-symbol">:</span> <a href="globals.html#tjsonschema" class="tsd-signature-type">TJSONSchema</a><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/types/string-json-schema.ts#L5">src/types/string-json-schema.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/types/string-json-schema.ts#L5">src/types/string-json-schema.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -293,10 +294,10 @@
 				<section class="tsd-panel tsd-member tsd-kind-variable tsd-is-not-exported">
 					<a name="uuid_pattern" class="tsd-anchor"></a>
 					<h3>UUID_<wbr>PATTERN</h3>
-					<div class="tsd-signature tsd-kind-icon">UUID_<wbr>PATTERN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> =&nbsp;&quot;^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$&quot;</span></div>
+					<div class="tsd-signature tsd-kind-icon">UUID_<wbr>PATTERN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> =&nbsp;/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/factories/uuid.ts#L5">src/factories/uuid.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/factories/uuid.ts#L6">src/factories/uuid.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -306,8 +307,8 @@
 					<div class="tsd-signature tsd-kind-icon">ajv<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Ajv</span><span class="tsd-signature-symbol"> =&nbsp;new AJV()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/test/factories/object.test.ts#L4">test/factories/object.test.ts:4</a></li>
-							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/test/factories/uuid.test.ts#L5">test/factories/uuid.test.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/test/factories/object.test.ts#L4">test/factories/object.test.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/test/factories/uuid.test.ts#L5">test/factories/uuid.test.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -324,7 +325,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/factories/all-of.ts#L3">src/factories/all-of.ts:3</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/factories/all-of.ts#L3">src/factories/all-of.ts:3</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -353,7 +354,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/factories/any.ts#L3">src/factories/any.ts:3</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/factories/any.ts#L3">src/factories/any.ts:3</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -376,7 +377,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/factories/any-of.ts#L3">src/factories/any-of.ts:3</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/factories/any-of.ts#L3">src/factories/any-of.ts:3</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -405,7 +406,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/factories/array.ts#L6">src/factories/array.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/factories/array.ts#L6">src/factories/array.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -431,7 +432,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/factories/boolean.ts#L6">src/factories/boolean.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/factories/boolean.ts#L6">src/factories/boolean.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -454,7 +455,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/utils/clone.ts#L4">src/utils/clone.ts:4</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/utils/clone.ts#L4">src/utils/clone.ts:4</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -483,7 +484,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/utils/clone-with.ts#L4">src/utils/clone-with.ts:4</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/utils/clone-with.ts#L4">src/utils/clone-with.ts:4</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -515,7 +516,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/factories/date-time.ts#L6">src/factories/date-time.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/factories/date-time.ts#L6">src/factories/date-time.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -538,7 +539,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/factories/email.ts#L6">src/factories/email.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/factories/email.ts#L6">src/factories/email.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -561,7 +562,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/factories/enumeration.ts#L10">src/factories/enumeration.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/factories/enumeration.ts#L8">src/factories/enumeration.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -593,7 +594,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/factories/integer.ts#L6">src/factories/integer.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/factories/integer.ts#L6">src/factories/integer.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -616,7 +617,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/factories/list.ts#L6">src/factories/list.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/factories/list.ts#L6">src/factories/list.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -632,6 +633,38 @@
 						</li>
 					</ul>
 				</section>
+				<section class="tsd-panel tsd-member tsd-kind-function tsd-has-type-parameter">
+					<a name="mergewith" class="tsd-anchor"></a>
+					<h3>merge<wbr>With</h3>
+					<ul class="tsd-signatures tsd-kind-function tsd-has-type-parameter">
+						<li class="tsd-signature tsd-kind-icon">merge<wbr>With&lt;T&gt;<span class="tsd-signature-symbol">(</span>schema<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span>, overrides<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<ul>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/utils/merge-with.ts#L5">src/utils/merge-with.ts:5</a></li>
+								</ul>
+							</aside>
+							<h4 class="tsd-type-parameters-title">Type parameters</h4>
+							<ul class="tsd-type-parameters">
+								<li>
+									<h4>T<span class="tsd-signature-symbol">: </span><a href="globals.html#tjsonschema" class="tsd-signature-type">TJSONSchema</a></h4>
+								</li>
+							</ul>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5>schema: <span class="tsd-signature-type">T</span></h5>
+								</li>
+								<li>
+									<h5>overrides: <span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span></h5>
+								</li>
+							</ul>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">T</span></h4>
+						</li>
+					</ul>
+				</section>
 				<section class="tsd-panel tsd-member tsd-kind-function">
 					<a name="number" class="tsd-anchor"></a>
 					<h3>number</h3>
@@ -642,7 +675,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/factories/number.ts#L6">src/factories/number.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/factories/number.ts#L6">src/factories/number.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -665,7 +698,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/factories/object.ts#L7">src/factories/object.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/factories/object.ts#L7">src/factories/object.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -696,7 +729,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/utils/omit-properties.ts#L5">src/utils/omit-properties.ts:5</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/utils/omit-properties.ts#L5">src/utils/omit-properties.ts:5</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -722,7 +755,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/factories/one-of.ts#L3">src/factories/one-of.ts:3</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/factories/one-of.ts#L3">src/factories/one-of.ts:3</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -751,7 +784,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/utils/pick-properties.ts#L5">src/utils/pick-properties.ts:5</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/utils/pick-properties.ts#L5">src/utils/pick-properties.ts:5</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -777,7 +810,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/utils/require-properties.ts#L5">src/utils/require-properties.ts:5</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/utils/require-properties.ts#L5">src/utils/require-properties.ts:5</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -811,7 +844,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/factories/string.ts#L6">src/factories/string.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/factories/string.ts#L6">src/factories/string.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -834,7 +867,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/utils/to-string-reg-exp.ts#L1">src/utils/to-string-reg-exp.ts:1</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/utils/to-string-reg-exp.ts#L1">src/utils/to-string-reg-exp.ts:1</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -857,7 +890,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/factories/tuple.ts#L6">src/factories/tuple.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/factories/tuple.ts#L6">src/factories/tuple.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -883,7 +916,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/93ec14f/src/factories/uuid.ts#L7">src/factories/uuid.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/bluebirds-blue-jay/schema/blob/ec07dbc/src/factories/uuid.ts#L8">src/factories/uuid.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -982,6 +1015,9 @@
 					</li>
 					<li class=" tsd-kind-function">
 						<a href="globals.html#list" class="tsd-kind-icon">list</a>
+					</li>
+					<li class=" tsd-kind-function tsd-has-type-parameter">
+						<a href="globals.html#mergewith" class="tsd-kind-icon">merge<wbr>With</a>
 					</li>
 					<li class=" tsd-kind-function">
 						<a href="globals.html#number" class="tsd-kind-icon">number</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -254,6 +254,9 @@
 					<li class=" tsd-kind-function">
 						<a href="globals.html#list" class="tsd-kind-icon">list</a>
 					</li>
+					<li class=" tsd-kind-function tsd-has-type-parameter">
+						<a href="globals.html#mergewith" class="tsd-kind-icon">merge<wbr>With</a>
+					</li>
 					<li class=" tsd-kind-function">
 						<a href="globals.html#number" class="tsd-kind-icon">number</a>
 					</li>

--- a/index.ts
+++ b/index.ts
@@ -28,6 +28,7 @@ export { TStringJSONSchema } from './src/types/string-json-schema';
 export { cleanOptions } from './src/utils/clean-options';
 export { clone } from './src/utils/clone';
 export { cloneWith } from './src/utils/clone-with';
+export { mergeWith } from './src/utils/merge-with';
 export { makeSchema } from './src/utils/make-schema';
 export { nullable } from './src/utils/nullable';
 export { omitProperties } from './src/utils/omit-properties';

--- a/src/utils/merge-with.ts
+++ b/src/utils/merge-with.ts
@@ -3,5 +3,10 @@ import { TJSONSchema } from '../types/json-schema';
 import { clone } from './clone';
 
 export function mergeWith<T extends TJSONSchema = TJSONSchema> (schema: T, overrides: Partial<T>): T {
-  return Lodash.merge(clone(schema), overrides);
+  return Lodash.mergeWith(clone(schema), overrides, (obj: any, src: any) => {
+    if (Lodash.isArray(obj)) {
+      return obj.concat(src);
+    }
+    return undefined;
+  });
 }

--- a/src/utils/merge-with.ts
+++ b/src/utils/merge-with.ts
@@ -1,0 +1,7 @@
+import * as Lodash from 'lodash';
+import { TJSONSchema } from '../types/json-schema';
+import { clone } from './clone';
+
+export function mergeWith<T extends TJSONSchema = TJSONSchema> (schema: T, overrides: Partial<T>): T {
+  return Lodash.merge(clone(schema), overrides);
+}

--- a/test/utils/clone-with.test.ts
+++ b/test/utils/clone-with.test.ts
@@ -1,0 +1,26 @@
+import * as Schema from '../../';
+
+describe('cloneWith()', function () {
+  it('should return a cloned object schema', () => {
+    const schema = Schema.object({
+      foo: Schema.string()
+    }, {
+      required: ['foo'],
+      additionalProperties: true
+    });
+
+    const cloned = Schema.cloneWith(schema, Schema.object({ bar: Schema.string() }, {
+      additionalProperties: true,
+      nullable: true
+    }));
+
+    expect(cloned).to.deep.equal({
+      type: ['object', 'null'],
+      required: ['foo'],
+      additionalProperties: true,
+      properties: {
+        bar: { type: 'string' }
+      }
+    });
+  });
+});

--- a/test/utils/merge-with.test.ts
+++ b/test/utils/merge-with.test.ts
@@ -12,13 +12,14 @@ describe('mergeWith()', function () {
     const merged = Schema.mergeWith(schema, Schema.object({
       bar: Schema.string()
     }, {
+      required: ['bar'],
       additionalProperties: true,
       nullable: true
     }));
 
     expect(merged).to.deep.equal({
       type: ['object', 'null'],
-      required: ['foo'],
+      required: ['foo', 'bar'],
       additionalProperties: true,
       properties: {
         foo: { type: 'string' },

--- a/test/utils/merge-with.test.ts
+++ b/test/utils/merge-with.test.ts
@@ -1,0 +1,29 @@
+import * as Schema from '../../';
+
+describe('mergeWith()', function () {
+  it('should return a merged object schema', () => {
+    const schema = Schema.object({
+      foo: Schema.string()
+    }, {
+      required: ['foo'],
+      additionalProperties: true
+    });
+
+    const merged = Schema.mergeWith(schema, Schema.object({
+      bar: Schema.string()
+    }, {
+      additionalProperties: true,
+      nullable: true
+    }));
+
+    expect(merged).to.deep.equal({
+      type: ['object', 'null'],
+      required: ['foo'],
+      additionalProperties: true,
+      properties: {
+        foo: { type: 'string' },
+        bar: { type: 'string' }
+      }
+    });
+  });
+});


### PR DESCRIPTION
This is actually how I had `cloneWith` expected to work. Unfortunately `cloneWith` overwrites existing attributes (mainly a problem with `properties`), so here is: `mergeWith`, which does exactly that, it merges attributes/properties instead of overwriting them.

The main usecase is that i.e. I have a already complex schema and want to "extend" one, but adding one attribute, which is very easy with `mergeWith` (see new test).